### PR TITLE
添加对特殊字符的支持

### DIFF
--- a/main.py
+++ b/main.py
@@ -395,13 +395,12 @@ class LMArenaPlugin(Star):
         }
 
         base_url = self.api_base_url.strip().removesuffix("/")
-        endpoint = (
-            f"{base_url}/v1beta/models/{model_name}:generateContent?key={api_key}"
-        )
+        endpoint = f"{base_url}/v1beta/models/{model_name}:generateContent"
         headers = {"Content-Type": "application/json"}
 
+        # 使用 params 参数传递 api_key，aiohttp 会自动进行 URL 编码
         async with self.iwf.session.post(
-            url=endpoint, json=payload, headers=headers
+            url=endpoint, json=payload, headers=headers, params={"key": api_key}
         ) as response:
             if response.status != 200:
                 response_text = await response.text()


### PR DESCRIPTION
### 当 API key 包含特殊字符（如 +、=、/、& 等 URL 保留字符）时，直接拼接到 URL 会导致：
1. URL 解析错误
2. 服务器无法正确识别 key
3. 请求失败

### 解决方案：
- 使用 aiohttp 的 params 参数自动编码